### PR TITLE
Add missing returns in seek events

### DIFF
--- a/BasicPlaybackTVKotlin/src/main/java/com/bitmovin/samples/tv/playback/basic/MainActivity.kt
+++ b/BasicPlaybackTVKotlin/src/main/java/com/bitmovin/samples/tv/playback/basic/MainActivity.kt
@@ -114,10 +114,12 @@ class MainActivity : AppCompatActivity() {
             KeyEvent.KEYCODE_DPAD_RIGHT,
             KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> {
                 player.seekForward()
+                return true
             }
             KeyEvent.KEYCODE_DPAD_LEFT,
             KeyEvent.KEYCODE_MEDIA_REWIND -> {
                 player.seekBackward()
+                return true
             }
         }
 


### PR DESCRIPTION
I only tested the Kotlin version, not the Java one. (add the returns there too?)
The addition of these returns improves the seek functionality